### PR TITLE
Prevent use of inputs which dont have enough maturity.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -244,6 +244,9 @@ public:
             /* nTime    */ 0,
             /* nTxCount */ 0,
             /* dTxRate  */ 0};
+
+        /* disable fallback fee on mainnet */
+        m_fallback_fee_enabled = true;
     }
 };
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3062,7 +3062,7 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
             CFeeRate nFeeRateNeeded = GetMinimumFeeRate(*this, coin_control, &feeCalc);
 
             nFeeRet = 0;
-            bool pick_new_inputs = true;
+            bool pick_new_inputs = false;
             CAmount nValueIn = 0;
 
             // BnB selector is the only selector used when this is true.


### PR DESCRIPTION
Prevent CreateTransaction() from selecting freshly minted coins; which upset AcceptToMemoryPoolWorker due to insufficient confirms.