### PR TITLE
update PoS seen stake hashes

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -164,6 +164,7 @@ public:
 
         // Stake constants
         consensus.nStakeEnforcement = 70000;
+        consensus.nStakeEnforcementCheck = 85000;
         consensus.nMinStakeAmount = 200 * COIN;
         consensus.nMinStakeHistory = 360;
 
@@ -300,7 +301,8 @@ public:
         consensus.nMasternodeMinimumConfirmations = 1;
 
         // Stake constants
-        consensus.nStakeEnforcement = 60000;
+        consensus.nStakeEnforcement = 0;
+        consensus.nStakeEnforcementCheck = 0;
         consensus.nMinStakeAmount = 150 * COIN;
         consensus.nMinStakeHistory = 600;
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -164,7 +164,6 @@ public:
 
         // Stake constants
         consensus.nStakeEnforcement = 70000;
-        consensus.nStakeEnforcementCheck = 85000;
         consensus.nMinStakeAmount = 200 * COIN;
         consensus.nMinStakeHistory = 360;
 
@@ -301,8 +300,7 @@ public:
         consensus.nMasternodeMinimumConfirmations = 1;
 
         // Stake constants
-        consensus.nStakeEnforcement = 0;
-        consensus.nStakeEnforcementCheck = 0;
+        consensus.nStakeEnforcement = 60000;
         consensus.nMinStakeAmount = 150 * COIN;
         consensus.nMinStakeHistory = 600;
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -171,9 +171,7 @@ struct Params {
     CAmount nMinStakeAmount;
     int nMinStakeHistory;
     int nStakeEnforcement;
-    int nStakeEnforcementCheck;
     int StakeEnforcement() const { return nStakeEnforcement; }
-    int StakeEnforcementCheck() const { return nStakeEnforcementCheck; }
     CAmount MinStakeAmount() const { return nMinStakeAmount; }
     int MinStakeHistory() const { return nMinStakeHistory; }
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -171,7 +171,7 @@ struct Params {
     CAmount nMinStakeAmount;
     int nMinStakeHistory;
     int nStakeEnforcement;
-    CAmount StakeEnforcement() const { return nStakeEnforcement; }
+    int StakeEnforcement() const { return nStakeEnforcement; }
     CAmount MinStakeAmount() const { return nMinStakeAmount; }
     int MinStakeHistory() const { return nMinStakeHistory; }
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -171,7 +171,9 @@ struct Params {
     CAmount nMinStakeAmount;
     int nMinStakeHistory;
     int nStakeEnforcement;
+    int nStakeEnforcementCheck;
     int StakeEnforcement() const { return nStakeEnforcement; }
+    int StakeEnforcementCheck() const { return nStakeEnforcementCheck; }
     CAmount MinStakeAmount() const { return nMinStakeAmount; }
     int MinStakeHistory() const { return nMinStakeHistory; }
 

--- a/src/pos/kernel.cpp
+++ b/src/pos/kernel.cpp
@@ -303,8 +303,7 @@ bool CheckStakeKernelHash(unsigned int nBits, CBlockIndex* pindexPrev, const CBl
         if (!fHardenedChecks) {
             return error("%s: nTime violation", __func__);
         } else {
-            LogPrintf("Timestamp violation (nTimeTx < txPrevTime)\n");
-            return false;
+            return error("%s: timestamp violation (nTimeTx < txPrevTime)", __func__);
         }
     }
 
@@ -314,8 +313,7 @@ bool CheckStakeKernelHash(unsigned int nBits, CBlockIndex* pindexPrev, const CBl
         if (!fHardenedChecks) {
             return error("%s: min age violation", __func__);
         } else {
-            LogPrintf("Minimum age violation (nTimeBlockFrom + params.nStakeMinAge > nTimeTx)\n");
-            return false;
+            return error("%s: min age violation (nTimeBlockFrom + params.nStakeMinAge > nTimeTx)", __func__);
         }
     }
 
@@ -326,7 +324,7 @@ bool CheckStakeKernelHash(unsigned int nBits, CBlockIndex* pindexPrev, const CBl
     //! enforce minimum stake amount
     if (nValueIn < Params().GetConsensus().MinStakeAmount() && fHardenedChecks) {
         fSpamNode = true; //! solely for PoS spam
-        return false;
+        return error("%s: min input violation", __func__);
     }
 
     // v0.3 protocol kernel hash weight starts from 0 at the 30-day min age
@@ -410,12 +408,11 @@ bool CheckProofOfStake(const CBlock &block, CBlockIndex* pindexPrev, uint256& ha
 
     // returning zero from GetLastHeight() indicates error
     if (nBlockFromHeight == 0 && fHardenedChecks)
-        return false;
+        return error("%s: returning zero from GetLastHeight()", __func__);
 
     if (!Params().GetConsensus().HasStakeMinDepth(nPreviousBlockHeight+1, nBlockFromHeight) && fHardenedChecks) {
         fSpamNode = true;
-        LogPrintf("\n%s : min age violation - height=%d - nHeightBlockFrom=%d (depth=%d)\n", __func__, nPreviousBlockHeight, nBlockFromHeight, nPreviousBlockHeight - nBlockFromHeight);
-        return false;
+        return error("%s: min age violation - height=%d - nHeightBlockFrom=%d (depth=%d)", __func__, nPreviousBlockHeight, nBlockFromHeight, nPreviousBlockHeight - nBlockFromHeight);
     }
 
     CBlockHeader header = LookupBlockIndex(hashBlock)->GetBlockHeader();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1771,7 +1771,7 @@ bool CChainState::PoSContextualBlockChecks(const CBlock& block, CValidationState
     }
 
     // make sure we havent seen this stake previously
-    if (pindex->nHeight >= Params().GetConsensus().StakeEnforcementCheck() &&
+    if (pindex->nHeight >= Params().GetConsensus().StakeEnforcement() &&
         std::find(m_blockman.m_pos_index.begin(), m_blockman.m_pos_index.end(), hashProofOfStake) != m_blockman.m_pos_index.end()) {
         LogPrintf(" * already seen this stake (%s), discarding block..\n", hashProofOfStake.ToString());
         return false;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1771,7 +1771,7 @@ bool CChainState::PoSContextualBlockChecks(const CBlock& block, CValidationState
     }
 
     // make sure we havent seen this stake previously
-    if (pindex->nHeight >= Params().GetConsensus().StakeEnforcement() &&
+    if (pindex->nHeight >= Params().GetConsensus().StakeEnforcementCheck() &&
         std::find(m_blockman.m_pos_index.begin(), m_blockman.m_pos_index.end(), hashProofOfStake) != m_blockman.m_pos_index.end()) {
         LogPrintf(" * already seen this stake (%s), discarding block..\n", hashProofOfStake.ToString());
         return false;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -110,7 +110,6 @@ CChain& ChainActive() { return g_chainstate.m_chain; }
  */
 RecursiveMutex cs_main;
 
-std::vector<uint256> vecStakeSeen;
 CBlockIndex *pindexBestHeader = nullptr;
 Mutex g_best_block_mutex;
 std::condition_variable g_best_block_cv;
@@ -1761,13 +1760,7 @@ static int64_t nBlocksTotal = 0;
 /**
  * proof-of-stake
  */
-void maintainStakeSeen()
-{
-    if (vecStakeSeen.size() > 1024)
-        vecStakeSeen.erase(vecStakeSeen.begin(), vecStakeSeen.begin() + 128);
-}
-
-bool PoSContextualBlockChecks(const CBlock& block, CValidationState& state, CBlockIndex* pindex, bool &fSpamNode, bool fJustCheck)
+bool CChainState::PoSContextualBlockChecks(const CBlock& block, CValidationState& state, CBlockIndex* pindex, bool &fSpamNode, bool fJustCheck)
 {
     uint256 hashProofOfStake = uint256();
 
@@ -1777,15 +1770,15 @@ bool PoSContextualBlockChecks(const CBlock& block, CValidationState& state, CBlo
         return false; // do not error here as we expect this during initial block download
     }
 
-    //! make sure we havent seen this stake previously
-    for (const auto& seenStake : vecStakeSeen) {
-       if (seenStake == hashProofOfStake &&
-           pindex->nHeight >= Params().GetConsensus().nStakeEnforcement) {
-           LogPrintf(" * already seen this stake (%s), discarding block..\n", hashProofOfStake.ToString().c_str());
-           return false;
-       }
+    // make sure we havent seen this stake previously
+    if (pindex->nHeight >= Params().GetConsensus().StakeEnforcement() &&
+        std::find(m_blockman.m_pos_index.begin(), m_blockman.m_pos_index.end(), hashProofOfStake) != m_blockman.m_pos_index.end()) {
+        LogPrintf(" * already seen this stake (%s), discarding block..\n", hashProofOfStake.ToString());
+        return false;
     }
-    maintainStakeSeen();
+
+    // set stake hash as seen
+    m_blockman.InsertPoSIndex(hashProofOfStake);
 
     // compute stake entropy bit for stake modifier
     unsigned int nEntropyBit = GetStakeEntropyBit(block);
@@ -1821,9 +1814,6 @@ bool PoSContextualBlockChecks(const CBlock& block, CValidationState& state, CBlo
 
     if (fJustCheck)
         return true;
-
-    //! if we get this far, its good
-    vecStakeSeen.push_back(hashProofOfStake);
 
     // write everything to index
     if (block.IsProofOfStake())
@@ -3858,7 +3848,6 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
     uint256 hashProofOfStake = uint256();
     if (!block.nNonce) {
         bool fValid = CheckProofOfStake(block, pindex->pprev, hashProofOfStake, *fSpamNode);
-        LogPrintf("hashProof = %s\n", hashProofOfStake.ToString().c_str());
         if (!fValid) {
             LogPrintf("WARNING: %s: check proof-of-stake failed for block %s\n", __func__, block.GetHash().ToString());
             return false;
@@ -4170,12 +4159,27 @@ CBlockIndex * BlockManager::InsertBlockIndex(const uint256& hash)
     return pindexNew;
 }
 
+void BlockManager::InsertPoSIndex(const uint256& hash)
+{
+    AssertLockHeld(cs_main);
+
+    if (hash.IsNull())
+        return;
+
+    // Check if exists
+    if (std::find(m_pos_index.begin(), m_pos_index.end(), hash) != m_pos_index.end())
+        return;
+
+    // Create new
+    m_pos_index.push_back(hash);
+}
+
 bool BlockManager::LoadBlockIndex(
     const Consensus::Params& consensus_params,
     CBlockTreeDB& blocktree,
     std::set<CBlockIndex*, CBlockIndexWorkComparator>& block_index_candidates)
 {
-    if (!blocktree.LoadBlockIndexGuts(consensus_params, [this](const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return this->InsertBlockIndex(hash); }))
+    if (!blocktree.LoadBlockIndexGuts(consensus_params, [this](const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { CBlockIndex* idx = this->InsertBlockIndex(hash); if (!hash.IsNull()) {this->InsertPoSIndex(idx->hashProofOfStake);} return idx; }))
         return false;
 
     // Calculate nChainWork

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1766,15 +1766,13 @@ bool CChainState::PoSContextualBlockChecks(const CBlock& block, CValidationState
 
     // verify hash target and signature of coinstake tx
     if (block.IsProofOfStake() && !CheckProofOfStake(block, pindex->pprev, hashProofOfStake, fSpamNode)) {
-        LogPrintf("%s: check proof-of-stake failed for block %s\n", __func__, block.GetHash().ToString());
-        return false; // do not error here as we expect this during initial block download
+        return error("%s: check proof-of-stake failed for block %s", __func__, block.GetHash().ToString()); // do not error here as we expect this during initial block download
     }
 
     // make sure we havent seen this stake previously
     if (pindex->nHeight >= Params().GetConsensus().StakeEnforcement() &&
         std::find(m_blockman.m_pos_index.begin(), m_blockman.m_pos_index.end(), hashProofOfStake) != m_blockman.m_pos_index.end()) {
-        LogPrintf(" * already seen this stake (%s), discarding block..\n", hashProofOfStake.ToString());
-        return false;
+        return error(" * already seen this stake (%s), discarding block..", hashProofOfStake.ToString());
     }
 
     // set stake hash as seen

--- a/src/validation.h
+++ b/src/validation.h
@@ -453,6 +453,7 @@ class BlockManager {
 public:
     BlockMap m_block_index GUARDED_BY(cs_main);
     PrevBlockMap m_prev_block_index GUARDED_BY(cs_main);
+    std::vector<uint256> m_pos_index GUARDED_BY(cs_main);
 
     /** In order to efficiently track invalidity of headers, we keep the set of
       * blocks which we tried to connect and found to be invalid here (ie which
@@ -500,6 +501,8 @@ public:
     CBlockIndex* AddToBlockIndex(const CBlockHeader& block, bool fProofOfStake, enum BlockStatus nStatus = BLOCK_VALID_TREE) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     /** Create a new block index entry for a given block hash */
     CBlockIndex* InsertBlockIndex(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    /** Create a new PoS hash index entry for a given PoS hash */
+    void InsertPoSIndex(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /**
      * If a block header hasn't already been seen, call CheckBlockHeader on it, ensure
@@ -643,6 +646,8 @@ private:
 
     //! Mark a block as not having block data
     void EraseBlockData(CBlockIndex* index) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+    bool PoSContextualBlockChecks(const CBlock& block, CValidationState& state, CBlockIndex* pindex, bool &fSpamNode, bool fJustCheck);
 };
 
 /** Mark a block as precious and reorganize.


### PR DESCRIPTION
The current duplicated seen stake hashes system has a problem, mainly due to a list of stake hashes contained only temporarily in ram, this can cause chain splits: 
- newly started nodes accept any duplicate stake hash 
- active nodes prevent insertion, but only of the last N blocks
This patch creates a new hash list, contained in both ram and disk, reloaded at each reboot and updated at each block received.
